### PR TITLE
fix transform numbers like 8*

### DIFF
--- a/rome.py
+++ b/rome.py
@@ -61,7 +61,7 @@ class Roman(int):
                 continue
             pos = Roman(n)._positively()
             neg = Roman(n)._negatively()
-            s += neg if neg and len(neg) < len(pos) else pos
+            s += pos if str(n).startswith("8") else neg if neg and len(neg) < len(pos) else pos
         return s
 
     def __repr__(self):


### PR DESCRIPTION
Your lib have some problem with numbers, contain digit 8, for example:
python -c "from rome import Roman; print(Roman(8))"
IIX
I fixed this problem:
python -c "from rome import Roman; print(Roman(8))"
VIII

2008 as MMVIII
http://en.wikipedia.org/wiki/Roman_numerals
